### PR TITLE
Make the authorize page redirect to login if user logged out

### DIFF
--- a/oidc_provider/templates/oidc_provider/authorize.html
+++ b/oidc_provider/templates/oidc_provider/authorize.html
@@ -2,7 +2,7 @@
 
 <p>Client <strong>{{ client.name }}</strong> would like to access this information of you ...</p>
 
-<form method="post" action="{% url 'oidc_provider:authorize' %}">
+<form method="post">
 
     {% csrf_token %}
 

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -62,88 +62,30 @@ OIDC_TEMPLATES = settings.get('OIDC_TEMPLATES')
 
 
 class AuthorizeView(View):
+    """
+    Authorization request view.
+
+    See https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+    """
+
     authorize_endpoint_class = AuthorizeEndpoint
 
-    def get(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):
+        """
+        Validates required 'authorize' parameters.
+        If the user is not logged in and:
+        * the prompt value is 'none': a 'login_required' error will be returned.
+        * otherwise: the user will be redirected to the login page.
+
+        See:
+        """
+
         authorize = self.authorize_endpoint_class(request)
 
         try:
             authorize.validate_params()
 
-            if get_attr_or_callable(request.user, 'is_authenticated'):
-                # Check if there's a hook setted.
-                hook_resp = settings.get('OIDC_AFTER_USERLOGIN_HOOK', import_str=True)(
-                    request=request, user=request.user,
-                    client=authorize.client)
-                if hook_resp:
-                    return hook_resp
-
-                if 'login' in authorize.params['prompt']:
-                    if 'none' in authorize.params['prompt']:
-                        raise AuthorizeError(
-                            authorize.params['redirect_uri'], 'login_required',
-                            authorize.grant_type)
-                    else:
-                        django_user_logout(request)
-                        next_page = strip_prompt_login(request.get_full_path())
-                        return redirect_to_login(next_page, settings.get('OIDC_LOGIN_URL'))
-
-                if 'select_account' in authorize.params['prompt']:
-                    # TODO: see how we can support multiple accounts for the end-user.
-                    if 'none' in authorize.params['prompt']:
-                        raise AuthorizeError(
-                            authorize.params['redirect_uri'], 'account_selection_required',
-                            authorize.grant_type)
-                    else:
-                        django_user_logout(request)
-                        return redirect_to_login(
-                            request.get_full_path(), settings.get('OIDC_LOGIN_URL'))
-
-                if {'none', 'consent'}.issubset(authorize.params['prompt']):
-                    raise AuthorizeError(
-                        authorize.params['redirect_uri'], 'consent_required', authorize.grant_type)
-
-                implicit_flow_resp_types = {'id_token', 'id_token token'}
-                allow_skipping_consent = (
-                    authorize.client.client_type != 'public' or
-                    authorize.params['response_type'] in implicit_flow_resp_types)
-
-                if not authorize.client.require_consent and (
-                        allow_skipping_consent and
-                        'consent' not in authorize.params['prompt']):
-                    return redirect(authorize.create_response_uri())
-
-                if authorize.client.reuse_consent:
-                    # Check if user previously give consent.
-                    if authorize.client_has_user_consent() and (
-                            allow_skipping_consent and
-                            'consent' not in authorize.params['prompt']):
-                        return redirect(authorize.create_response_uri())
-
-                if 'none' in authorize.params['prompt']:
-                    raise AuthorizeError(
-                        authorize.params['redirect_uri'], 'consent_required', authorize.grant_type)
-
-                # Generate hidden inputs for the form.
-                context = {
-                    'params': authorize.params,
-                }
-                hidden_inputs = render_to_string('oidc_provider/hidden_inputs.html', context)
-
-                # Remove `openid` from scope list
-                # since we don't need to print it.
-                if 'openid' in authorize.params['scope']:
-                    authorize.params['scope'].remove('openid')
-
-                context = {
-                    'client': authorize.client,
-                    'hidden_inputs': hidden_inputs,
-                    'params': authorize.params,
-                    'scopes': authorize.get_scopes_information(),
-                }
-
-                return render(request, OIDC_TEMPLATES['authorize'], context)
-            else:
+            if not get_attr_or_callable(request.user, 'is_authenticated'):
                 if 'none' in authorize.params['prompt']:
                     raise AuthorizeError(
                         authorize.params['redirect_uri'], 'login_required', authorize.grant_type)
@@ -152,6 +94,8 @@ class AuthorizeView(View):
                     return redirect_to_login(next_page, settings.get('OIDC_LOGIN_URL'))
 
                 return redirect_to_login(request.get_full_path(), settings.get('OIDC_LOGIN_URL'))
+
+            return super().dispatch(request, authorize, *args, **kwargs)
 
         except (ClientIdError, RedirectUriError) as error:
             context = {
@@ -168,38 +112,99 @@ class AuthorizeView(View):
 
             return redirect(uri)
 
-    def post(self, request, *args, **kwargs):
-        authorize = self.authorize_endpoint_class(request)
+    def get(self, request, authorize, *args, **kwargs):
+        hook_resp = settings.get('OIDC_AFTER_USERLOGIN_HOOK', import_str=True)(
+            request=request, user=request.user,
+            client=authorize.client)
+        if hook_resp:
+            return hook_resp
 
-        try:
-            authorize.validate_params()
+        if 'login' in authorize.params['prompt']:
+            if 'none' in authorize.params['prompt']:
+                raise AuthorizeError(
+                    authorize.params['redirect_uri'], 'login_required',
+                    authorize.grant_type)
+            else:
+                django_user_logout(request)
+                next_page = strip_prompt_login(request.get_full_path())
+                return redirect_to_login(next_page, settings.get('OIDC_LOGIN_URL'))
 
-            if not request.POST.get('allow'):
-                signals.user_decline_consent.send(
-                    self.__class__, user=request.user,
-                    client=authorize.client, scope=authorize.params['scope'])
+        if 'select_account' in authorize.params['prompt']:
+            # TODO: see how we can support multiple accounts for the end-user.
+            if 'none' in authorize.params['prompt']:
+                raise AuthorizeError(
+                    authorize.params['redirect_uri'], 'account_selection_required',
+                    authorize.grant_type)
+            else:
+                django_user_logout(request)
+                return redirect_to_login(
+                    request.get_full_path(), settings.get('OIDC_LOGIN_URL'))
 
-                raise AuthorizeError(authorize.params['redirect_uri'],
-                                     'access_denied',
-                                     authorize.grant_type)
+        if {'none', 'consent'}.issubset(authorize.params['prompt']):
+            raise AuthorizeError(
+                authorize.params['redirect_uri'], 'consent_required', authorize.grant_type)
 
-            signals.user_accept_consent.send(
-                self.__class__, user=request.user, client=authorize.client,
-                scope=authorize.params['scope'])
+        implicit_flow_resp_types = {'id_token', 'id_token token'}
+        allow_skipping_consent = (
+            authorize.client.client_type != 'public' or
+            authorize.params['response_type'] in implicit_flow_resp_types)
 
-            # Save the user consent given to the client.
-            authorize.set_client_user_consent()
+        if not authorize.client.require_consent and (
+                allow_skipping_consent and
+                'consent' not in authorize.params['prompt']):
+            return redirect(authorize.create_response_uri())
 
-            uri = authorize.create_response_uri()
+        if authorize.client.reuse_consent:
+            # Check if user previously give consent.
+            if authorize.client_has_user_consent() and (
+                    allow_skipping_consent and
+                    'consent' not in authorize.params['prompt']):
+                return redirect(authorize.create_response_uri())
 
-            return redirect(uri)
+        if 'none' in authorize.params['prompt']:
+            raise AuthorizeError(
+                authorize.params['redirect_uri'], 'consent_required', authorize.grant_type)
 
-        except AuthorizeError as error:
-            uri = error.create_uri(
-                authorize.params['redirect_uri'],
-                authorize.params['state'])
+        # Generate hidden inputs for the form.
+        context = {
+            'params': authorize.params,
+        }
+        hidden_inputs = render_to_string('oidc_provider/hidden_inputs.html', context)
 
-            return redirect(uri)
+        # Remove `openid` from scope list
+        # since we don't need to print it.
+        if 'openid' in authorize.params['scope']:
+            authorize.params['scope'].remove('openid')
+
+        context = {
+            'client': authorize.client,
+            'hidden_inputs': hidden_inputs,
+            'params': authorize.params,
+            'scopes': authorize.get_scopes_information(),
+        }
+
+        return render(request, OIDC_TEMPLATES['authorize'], context)
+
+    def post(self, request, authorize, *args, **kwargs):
+        if not request.POST.get('allow'):
+            signals.user_decline_consent.send(
+                self.__class__, user=request.user,
+                client=authorize.client, scope=authorize.params['scope'])
+
+            raise AuthorizeError(authorize.params['redirect_uri'],
+                                 'access_denied',
+                                 authorize.grant_type)
+
+        signals.user_accept_consent.send(
+            self.__class__, user=request.user, client=authorize.client,
+            scope=authorize.params['scope'])
+
+        # Save the user consent given to the client.
+        authorize.set_client_user_consent()
+
+        uri = authorize.create_response_uri()
+
+        return redirect(uri)
 
 
 class TokenView(View):


### PR DESCRIPTION
If the user logs out in the middle of the authorisation grant they will be redirected back to the login page and be able to successfully complete the authorisation flow.