### PR TITLE
Run tests on supported python & django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 
 install:
   - pip install tox tox-travis coveralls

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Django OpenID Connect Provider
 
-[![Python Versions](https://img.shields.io/pypi/pyversions/django-oidc-provider.svg)](https://pypi.python.org/pypi/django-oidc-provider)
-[![PyPI Versions](https://img.shields.io/pypi/v/django-oidc-provider.svg)](https://pypi.python.org/pypi/django-oidc-provider)
-[![Documentation Status](https://readthedocs.org/projects/django-oidc-provider/badge/?version=master)](http://django-oidc-provider.readthedocs.io/)
-[![Travis](https://travis-ci.org/juanifioren/django-oidc-provider.svg?branch=master)](https://travis-ci.org/juanifioren/django-oidc-provider)
-
 ## About OpenID
 
 OpenID Connect is a simple identity layer on top of the OAuth 2.0 protocol, which allows computing clients to verify the identity of an end-user based on the authentication performed by an authorization server, as well as to obtain basic profile information about the end-user in an interoperable and REST-like manner. Like [Google](https://developers.google.com/identity/protocols/OpenIDConnect) for example.
@@ -13,8 +8,8 @@ OpenID Connect is a simple identity layer on top of the OAuth 2.0 protocol, whic
 
 `django-oidc-provider` can help you providing out of the box all the endpoints, data and logic needed to add OpenID Connect (and OAuth2) capabilities to your Django projects.
 
-Support for Python 3 and 2. Also latest versions of django.
+Supports all currently supported Python and Django versions. Currently this is Python 3.5+ and Django 1.11, 2.2, 3.0.
 
-[Read documentation for more info.](http://django-oidc-provider.readthedocs.org/)
+[Read the documentation.](http://django-oidc-provider.readthedocs.org/)
 
 [Do you want to contribute? Please read this.](http://django-oidc-provider.readthedocs.io/en/latest/sections/contribute.html)

--- a/docs/sections/scopesclaims.rst
+++ b/docs/sections/scopesclaims.rst
@@ -82,7 +82,7 @@ Somewhere in your Django ``settings.py``::
 
 Inside your oidc_provider_settings.py file add the following class::
 
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
     from oidc_provider.lib.claims import ScopeClaims
 
     class CustomScopeClaims(ScopeClaims):

--- a/oidc_provider/admin.py
+++ b/oidc_provider/admin.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from django.forms import ModelForm
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from oidc_provider import settings
 from oidc_provider.models import Client, Code, Token, RSAKeyDatabase, RSAKeyFilesystem

--- a/oidc_provider/lib/claims.py
+++ b/oidc_provider/lib/claims.py
@@ -1,6 +1,6 @@
 import copy
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from oidc_provider import settings
 

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings as django_settings
 from django.core.exceptions import ValidationError
 from Cryptodome.PublicKey import RSA

--- a/oidc_provider/templates/oidc_provider/check_session_iframe.html
+++ b/oidc_provider/templates/oidc_provider/check_session_iframe.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <html lang="en">
     <head>

--- a/oidc_provider/tests/cases/test_claims.py
+++ b/oidc_provider/tests/cases/test_claims.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
-from django.utils.six import text_type
 from django.utils.translation import override as override_language
 
 from oidc_provider.lib.claims import ScopeClaims, StandardScopeClaims, STANDARD_CLAIMS
@@ -61,7 +60,7 @@ class ClaimsTestCase(TestCase):
 
     def test_locale(self):
         with override_language('fr'):
-            self.assertEqual(text_type(StandardScopeClaims.info_profile[0]), 'Profil de base')
+            self.assertEqual(StandardScopeClaims.info_profile[0], 'Profil de base')
 
     def test_scopeclaims_class_inheritance(self):
         # Generate example class that will be used for `OIDC_EXTRA_SCOPE_CLAIMS` setting.

--- a/oidc_provider/tests/cases/test_commands.py
+++ b/oidc_provider/tests/cases/test_commands.py
@@ -1,6 +1,7 @@
+from io import StringIO
+
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils.six import StringIO
 
 
 class CommandsTest(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist=
-    py35-django{111,20,21},
-    py36-django{111,20,21},
-    py37-django{111,20,21},
+    py35-django{111, 22},
+    py36-django{111, 22,30},
+    py37-django{111, 22,30},
+    py38-django{111, 22,30}
 
 [testenv]
 changedir=
@@ -14,9 +15,9 @@ deps =
     pytest-django
     pytest-flake8
     pytest-cov
-    django111: django>=1.11,<1.12
-    django20: django>=2.0,<2.1
-    django21: django>=2.1,<2.2
+    django111: django>=1.11,<2.0
+    django22: django>=2.2,<2.3
+    django30: django>=3.0<3.1
 
 commands =
     pytest --flake8 --cov=oidc_provider {posargs}


### PR DESCRIPTION
Sets the test environment to run on currently supported python versions:
* 3.5
* 3.6
* 3.7
* 3.8

And on currently supported django versions:
* 1.11
* 2.2
* 3.0

Fixes #20